### PR TITLE
Encode function renames

### DIFF
--- a/examples/dice/die/die.go
+++ b/examples/dice/die/die.go
@@ -34,8 +34,8 @@ type Die struct {
 	Width float64
 }
 
-// EncodeFunction implements custom encoding for scad.EncodeFunction.
-func (d Die) EncodeFunction() (interface{}, error) {
+// EncodeSCAD implements custom encoding for scad.Encode.
+func (d Die) EncodeSCAD() (interface{}, error) {
 	return scad.Apply(
 		primitive3d.Cube{Size: value.NewFloat(d.Width)},
 		transformation.Translate{

--- a/examples/dice/die/dimples.go
+++ b/examples/dice/die/dimples.go
@@ -78,8 +78,8 @@ type Dimples struct {
 	Width float64
 }
 
-// EncodeFunction implements custom encoding for scad.EncodeFunction.
-func (d Dimples) EncodeFunction() (interface{}, error) {
+// EncodeSCAD implements custom encoding for scad.Encode.
+func (d Dimples) EncodeSCAD() (interface{}, error) {
 	children := make([]interface{}, len(dimplesPlacement))
 
 	for i, rotation := range dimplesPlacement {

--- a/examples/dice/dimples/dimple.go
+++ b/examples/dice/dimples/dimple.go
@@ -34,8 +34,8 @@ type Dimple struct {
 	Diameter float64
 }
 
-// EncodeFunction implements custom encoding for scad.EncodeFunction.
-func (d Dimple) EncodeFunction() (interface{}, error) {
+// EncodeSCAD implements custom encoding for scad.Encode.
+func (d Dimple) EncodeSCAD() (interface{}, error) {
 	sphereRadius := (math.Pow(d.Depth, 2) + math.Pow(d.Diameter/2, 2)) / (2 * d.Depth)
 
 	return scad.Apply(

--- a/examples/dice/dimples/dimples.go
+++ b/examples/dice/dimples/dimples.go
@@ -76,8 +76,8 @@ type Dimples struct {
 	Count int
 }
 
-// EncodeFunction implements custom encoding for scad.EncodeFunction.
-func (d Dimples) EncodeFunction() (interface{}, error) {
+// EncodeSCAD implements custom encoding for scad.Encode.
+func (d Dimples) EncodeSCAD() (interface{}, error) {
 	if d.Count < 0 || d.Count > 6 {
 		return nil, fmt.Errorf("dimples: Dimples Count is %d, must be between 0 and 6", d.Count)
 	}

--- a/pkg/scad/function_test.go
+++ b/pkg/scad/function_test.go
@@ -518,7 +518,7 @@ func Test_EncodeFunction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		gotFunction, err := EncodeFunction(test.input)
+		gotFunction, err := Encode(test.input)
 		gotError := err != nil
 
 		if gotError != test.wantError {

--- a/pkg/scad/scad.go
+++ b/pkg/scad/scad.go
@@ -71,12 +71,12 @@ type ModuleNameGetter interface {
 	GetModuleName() string
 }
 
-// FunctionEncoder is the interface for types that implement EncodeFunction.
-type FunctionEncoder interface {
-	// EncodeFunction returns a new interface that should be passed to scad.EncodeFunction,
-	// enabling overriding of encoding functionality, or more generally to permit an arbitrary
-	// type to define what its SCAD Function is.
-	EncodeFunction() (interface{}, error)
+// SCADEncoder is the interface for types that implement EncodeSCAD.
+type SCADEncoder interface {
+	// EncodeSCAD returns a new interface that should be passed to scad.EncodeSCAD, enabling
+	// overriding of encoding functionality, or more generally to permit an arbitrary type to
+	// define what object should be encoded in its place.
+	EncodeSCAD() (interface{}, error)
 }
 
 // EncodeFunction encodes an interface into a Function. The given interface must be a struct.
@@ -212,8 +212,8 @@ func EncodeFunction(i interface{}) (Function, error) {
 	}
 
 	// after all that, if the given interface is a FunctionEncoder, undo everything except module name
-	if iT.Implements(reflect.TypeOf((*FunctionEncoder)(nil)).Elem()) {
-		encodeFn, err := iV.Interface().(FunctionEncoder).EncodeFunction()
+	if iT.Implements(reflect.TypeOf((*SCADEncoder)(nil)).Elem()) {
+		encodeFn, err := iV.Interface().(SCADEncoder).EncodeSCAD()
 		if err != nil {
 			return Function{}, err
 		}

--- a/pkg/scad/scad.go
+++ b/pkg/scad/scad.go
@@ -23,7 +23,7 @@ import (
 
 // FunctionContent returns the OpenSCAD content for an input interface.
 func FunctionContent(i interface{}) (string, error) {
-	fn, err := EncodeFunction(i)
+	fn, err := Encode(i)
 	if err != nil {
 		return "", err
 	}
@@ -33,7 +33,7 @@ func FunctionContent(i interface{}) (string, error) {
 
 // Write writes a given interface as a Function to the given location.
 func Write(p string, i interface{}) error {
-	fn, err := EncodeFunction(i)
+	fn, err := Encode(i)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ type SCADEncoder interface {
 	EncodeSCAD() (interface{}, error)
 }
 
-// EncodeFunction encodes an interface into a Function. The given interface must be a struct.
+// Encode encodes an interface into a scad.Function. The given interface must be a struct.
 //
 // The resulting Function will have values applied based on the struct fields implementing
 // one or more of these interfaces:
@@ -112,7 +112,7 @@ type SCADEncoder interface {
 // as long no more than one sets a value)
 //
 // • Multiple Children fields are found
-func EncodeFunction(i interface{}) (Function, error) {
+func Encode(i interface{}) (Function, error) {
 	var fn Function
 
 	if i == nil {
@@ -200,7 +200,7 @@ func EncodeFunction(i interface{}) (Function, error) {
 			children := make([]Function, fieldV.Len())
 
 			for i := 0; i < fieldV.Len(); i++ {
-				child, err := EncodeFunction(fieldV.Index(i).Interface())
+				child, err := Encode(fieldV.Index(i).Interface())
 				if err != nil {
 					return Function{}, err
 				}
@@ -218,7 +218,7 @@ func EncodeFunction(i interface{}) (Function, error) {
 			return Function{}, err
 		}
 
-		encoderFn, err := EncodeFunction(encodeFn)
+		encoderFn, err := Encode(encodeFn)
 		if err != nil {
 			return Function{}, err
 		}


### PR DESCRIPTION
Closes #23
Closes #24

Rename interface `FunctionEncoder` to `SCADEncoder`, and its method from `EncodeFunction` to `EncodeSCAD`.

Renamed `scad.EncodeFunction` to `scad.Encode`.